### PR TITLE
Added deprecation warnings suppress flag if OS is Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ ifeq "$(OS)" "Linux"
 	FRAMEWORK	=
 endif
 ifeq "$(OS)" "Darwin"
+	CFLAGS += -DGL_SILENCE_DEPRECATION
 	INSTALL_NAME = -install_name $(CURRENT_DIR)/$(DYNAMIC_NAME)
 endif
 


### PR DESCRIPTION
As reported by Apple [https://developer.apple.com/macos/whats-new/](here) and suggested by compiler, I added **GL_SILENCE_DEPRECATION** flag to **CFLAGS** is OS is Darwin.